### PR TITLE
Update minimum working buffer size

### DIFF
--- a/src/Iconic.Zlib.Netstandard/DeflateStream.cs
+++ b/src/Iconic.Zlib.Netstandard/DeflateStream.cs
@@ -333,10 +333,9 @@ namespace Ionic.Zlib
 		///
 		/// <remarks>
 		/// <para>
-		///   The working buffer is used for all stream operations.  The default size is
-		///   1024 bytes.  The minimum size is 128 bytes. You may get better performance
-		///   with a larger buffer.  Then again, you might not.  You would have to test
-		///   it.
+		///   The working buffer is used for all stream operations. The Default size is 8192 bytes
+		///   on NETCF; 16384 bytes otherwise. The minimum size is 128 bytes. You may get better
+		///   performance with a larger buffer. Then again, you might not. You would have to test it.
 		/// </para>
 		///
 		/// <para>

--- a/src/Iconic.Zlib.Netstandard/GZipStream.cs
+++ b/src/Iconic.Zlib.Netstandard/GZipStream.cs
@@ -560,10 +560,9 @@ namespace Ionic.Zlib
 		///
 		/// <remarks>
 		/// <para>
-		///   The working buffer is used for all stream operations.  The default size is
-		///   1024 bytes.  The minimum size is 128 bytes. You may get better performance
-		///   with a larger buffer.  Then again, you might not.  You would have to test
-		///   it.
+		///   The working buffer is used for all stream operations. The Default size is 8192 bytes
+		///   on NETCF; 16384 bytes otherwise. The minimum size is 128 bytes. You may get better
+		///   performance with a larger buffer. Then again, you might not. You would have to test it.
 		/// </para>
 		///
 		/// <para>

--- a/src/Iconic.Zlib.Netstandard/ZlibConstants.cs
+++ b/src/Iconic.Zlib.Netstandard/ZlibConstants.cs
@@ -111,7 +111,7 @@ namespace Ionic.Zlib
 		public const int Z_BUF_ERROR = -5;
 
 		/// <summary>
-		/// The size of the working buffer used in the ZlibCodec class. Defaults to 8192 bytes.
+		/// The size of the working buffer used in the ZlibCodec class. Defaults to 8192 bytes on NETCF; 16384 bytes otherwise.
 		/// </summary>
 #if NETCF
         public const int WorkingBufferSizeDefault = 8192;
@@ -121,7 +121,7 @@ namespace Ionic.Zlib
 		/// <summary>
 		/// The minimum size of the working buffer used in the ZlibCodec class.  Currently it is 128 bytes.
 		/// </summary>
-		public const int WorkingBufferSizeMin = 1024;
+		public const int WorkingBufferSizeMin = 128;
 	}
 
 }

--- a/src/Iconic.Zlib.Netstandard/ZlibStream.cs
+++ b/src/Iconic.Zlib.Netstandard/ZlibStream.cs
@@ -342,10 +342,9 @@ namespace Ionic.Zlib
 		///
 		/// <remarks>
 		/// <para>
-		///   The working buffer is used for all stream operations.  The default size is
-		///   1024 bytes. The minimum size is 128 bytes. You may get better performance
-		///   with a larger buffer.  Then again, you might not.  You would have to test
-		///   it.
+		///   The working buffer is used for all stream operations. The Default size is 8192 bytes
+		///   on NETCF; 16384 bytes otherwise. The minimum size is 128 bytes. You may get better
+		///   performance with a larger buffer. Then again, you might not. You would have to test it.
 		/// </para>
 		///
 		/// <para>


### PR DESCRIPTION
I noticed that the `BufferSize` property mentioned a minimum size of 128, however, it was being set to 1024 in `ZlibConstants`.

Ran into an exception being thrown because I was attempting to set the buffer size to 922.

Figured I'd open a pull request to change the constant value to match the remarks comment 👍 